### PR TITLE
Update README with installation guide for Non-debian-based distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,5 +50,71 @@ This way installation is much easier. Since it's a Chinese service it might not 
 3. Click on "Install".
 4. Enjoy!
 
+## Installation for Non-Debian-based Distributions
+
+If you are using a non-Debian-based Linux distribution (i.e., distributions that don't use the deb package format), refer to the following.
+The `deb` package files provided by this repository are convenient enough for Debian-based distributions, but for other distributions, a `deb` package file doesn't offer much help.  
+Here, we'll use Arch Linux as an example. For other distributions, please find and install the relevant programs on your own.
+
+### Installation
+- Install the required programs **spark-dwine-helper**, **dpkg**, and **7z**
+```bash
+$ sudo pacman -S spark-dwine-helper dpkg p7zip
+```
+
+- Download the `.deb` package provided by the [Lyricify-on-Wine](https://github.com/Lyricify/Lyricify-on-Wine) repository, unpack it, and you can delete the remaining files as needed
+```bash
+$ curl -OL https://github.com/Lyricify/Lyricify-on-Wine/releases/download/Lyricify4/com.wxriw.lyricify4_4.2.28.240502-release-wpack240503.02_amd64.deb
+$ dpkg -X com.wxriw.lyricify4_4.2.28.240502-release-wpack240503.02_amd64.deb Lyricify
+$ mv Lyricify/opt/apps/com.wxriw.lyricify4/files/files.7z Lyricify/opt/apps/com.wxriw.lyricify4/files/wine_archive.7z .
+$ 7z x wine_archive.7z -o./Wine-for-Lyricify
+$ 7z x files.7z -o./Lyricify
+$ rm *7z
+```
+
+- Move the `Lyricify` folder to the default `WINEPREFIX` path corresponding to **spark-dwine-helper**
+```bash
+$ mv Lyricify/ ~/.deepinwine/
+```
+
+### Running
+At this point, you should be able to run Lyricify 4 normally. Here, we assume the initial working directory is `~/.Lyricify`
+```bash
+$ APPRUN_CMD=~/,Lyricify/Wine-for-Lyricify/bin/wine64 /opt/deepinwine/tools/spark_run_v4.sh "Lyricify" "4.2.28.240502-release-wpack240503.02" "C:/Program Files/Lyricify 4/Lyricify for Spotify.exe"
+```
+
+### Writing a `.desktop` file to integrate the application into the application menu
+Edit the `~/.local/share/applications/com.wxriw.lyricify4.desktop` file
+```
+#!/usr/bin/env xdg-open
+[Desktop Entry]
+Encoding=UTF-8
+Type=Application
+Categories=Audio;
+# The relative path of this file when unpacking should be
+# ./opt/apps/com.wxriw.lyricify4/entries/icons/hicolor/scalable/apps/com.wxriw.lyricify4.png
+Icon=~/.Lyricify/com.wxriw.lyricify4.png
+Exec="~/.Lyricify/run.sh" --uri 
+Name=Lyricify
+Comment=Lyricify 4 in a Wine container
+MimeType=
+GenericName=com.wxriw.lyricify4
+Terminal=false
+StartupNotify=false
+```
+
+Edit the `~/.Lyricify/run.sh` file
+```bash
+#!/bin/bash
+
+export APPRUN_CMD=~/.Lyricify/Wine-for-Lyricify/bin/wine64 
+/opt/deepinwine/tools/spark_run_v4.sh "Lyricify" "4.2.28.240502-release-wpack240503.02" "C:/Program Files/Lyricify 4/Lyricify for Spotify.exe"
+```
+
+## Some Possible Issues
+- When authorizing Spotify, the browser may not pop up normally. You need to click the `Problems logging in?` button in the lower left corner to manually open the browser for authorization.
+- If there are strange display issues with the application interface, opening `Settings-Apple Music Lyrics-Background-Dynamic` can alleviate this problem.
+
 ## Maintainer
 Packages in this repository are maintained by [Sheng Fan](https://github.com/fred913).  
+The installation methods for non-Debian based distributions are maintained by [Chumeng](https://github.com/lihaoze123).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -51,5 +51,74 @@ curl -fsSL https://cdn.jsdelivr.net/gh/Lyricify/Lyricify-on-Wine@master/install-
     2. 从 "apt-missing-dependencies" 目录安装依赖项：`sudo dpkg -i apt-missing-dependencies/*.deb`
     3. 使用 `apt` 安装从 Github Releases 下载的 .deb 包中的 Lyricify 软件包。
     4. 尽情享用！
+- 如果你使用非 Debian 系 Linux 发行版（即不适用 deb 软件包格式的发行版），参考下文。
+
+## 非 Debian 系发行版的安装
+
+该仓库提供的 `deb` 包文件对于 Debian 系发行版已经足够方便，但是对于其他发行版来说，一个 `deb` 包文件并不能提供很大的帮助。  
+这里以 Arch linux 举例，对于其他发行版，使用到的相关程序请自行查找安装方法。
+
+### 安装
+- 安装要用到的程序 **spark-dwine-helper**，**dpkg** 和 **7z**
+```bash
+$ sudo pacman -S spark-dwine-helper dpkg p7zip
+```
+
+- 下载 [Lyricify-on-Wine](https://github.com/Lyricify/Lyricify-on-Wine) 仓库提供的 `.deb` 包，并解包，剩余的文件可以自行删除
+```bash
+$ curl -OL https://github.com/Lyricify/Lyricify-on-Wine/releases/download/Lyricify4/com.wxriw.lyricify4_4.2.28.240502-release-wpack240503.02_amd64.deb
+$ dpkg -X com.wxriw.lyricify4_4.2.28.240502-release-wpack240503.02_amd64.deb Lyricify
+$ mv Lyricify/opt/apps/com.wxriw.lyricify4/files/files.7z Lyricify/opt/apps/com.wxriw.lyricify4/files/wine_archive.7z .
+$ 7z x wine_archive.7z -o./Wine-for-Lyricify
+$ 7z x files.7z -o./Lyricify
+$ rm *7z
+```
+
+- 将 `Lyricify` 文件夹移动到 **spark-dwine-helper** 所对应的默认 `WINEPREFIX` 路径
+```bash
+$ mv Lyricify/ ~/.deepinwine/
+```
+
+
+### 运行
+至此应该已经能正常地运行 Lyricify 4，这里假设最初的工作目录是 `~/.Lyricify`
+```bash
+$ APPRUN_CMD=~/,Lyricify/Wine-for-Lyricify/bin/wine64 /opt/deepinwine/tools/spark_run_v4.sh "Lyricify" "4.2.28.240502-release-wpack240503.02" "C:/Program Files/Lyricify 4/Lyricify for Spotify.exe"
+```
+
+
+### 编写 `.desktop` 文件以将应用程序集成到应用程序菜单中
+编辑 `~/.local/share/applications/com.wxriw.lyricify4.desktop` 文件
+```
+#!/usr/bin/env xdg-open
+[Desktop Entry]
+Encoding=UTF-8
+Type=Application
+Categories=Audio;
+# 解包时该文件的相对路径应该是
+# ./opt/apps/com.wxriw.lyricify4/entries/icons/hicolor/scalable/apps/com.wxriw.lyricify4.png
+Icon=~/.Lyricify/com.wxriw.lyricify4.png
+Exec="~/.Lyricify/run.sh" --uri 
+Name=Lyricify
+Comment=Lyricify 4 in a Wine container
+MimeType=
+GenericName=com.wxriw.lyricify4
+Terminal=false
+StartupNotify=false
+```
+
+编辑 `~/.Lyricify/run.sh` 文件
+```bash
+#!/bin/bash
+
+export APPRUN_CMD=~/.Lyricify/Wine-for-Lyricify/bin/wine64 
+/opt/deepinwine/tools/spark_run_v4.sh "Lyricify" "4.2.28.240502-release-wpack240503.02" "C:/Program Files/Lyricify 4/Lyricify for Spotify.exe"
+```
+
+## 一些可能的问题
+- 在进行 Spotify 授权的时候浏览器无法正常弹出，需要点击左下角的 `登录时遇到问题？` 按钮手动打开浏览器授权。
+- 应用界面出现奇怪的显示问题，打开 `设置-Apple Music 歌词-背景-动态` 可以缓解该问题。
+
 ## 维护者
 该仓库中的软件包由 [Sheng Fan](https://github.com/fred913) 维护。
+关于非 Debian 系发行版的安装方法由 [Chumeng](https://github.com/lihaoze123) 维护。


### PR DESCRIPTION
该仓库提供的 deb 包文件已经足够方便，但是对于其他发行版来说，一个 deb 包文件并不能提供很大的帮助。
解包后对照包内的脚本探索出了私以为在 Arch 系统上比较方便的使用方法。